### PR TITLE
Fix: Support for no bibliography being passed

### DIFF
--- a/src/typxidian.typ
+++ b/src/typxidian.typ
@@ -337,7 +337,7 @@
 
   if type(bib) == content {
     bib
-  } else {
+  } else if bib != none {
     bibliography(bib, title: bib-title)
   }
 


### PR DESCRIPTION
Closes #7 

Changes the else clause to an else if and checks if Bibliography is none, the default value in the template.