### PR TITLE
Fix acronym highlighting for mixed-case definitions (e.g., TTI)

### DIFF
--- a/src/acrostiche.typ
+++ b/src/acrostiche.typ
@@ -61,29 +61,39 @@
 
 
 #let highlight-words(acr, def) = {
-  let words = def.split()
-  let out = ()
   let matches = ()
   let acr_idx = 0
 
+  // Pass 1: Strict case-sensitive match
   for i in range(def.len()) {
-    let letter = def.at(i)
-
-    // Case sensitive match
-    if acr_idx < acr.len() and letter == acr.at(acr_idx) {
+    if acr_idx < acr.len() and def.at(i) == acr.at(acr_idx) {
       matches.push(i)
       acr_idx += 1
     }
   }
 
-
-  // Case-insensitive match
+  // Pass 2: Case-insensitive match prioritizing word boundaries
   if acr_idx < acr.len() {
+    matches = () // Reset matches array
+    acr_idx = 0  // Reset acronym pointer
+    
     for i in range(def.len()) {
-      let letter = def.at(i)
+      if acr_idx < acr.len() and upper(def.at(i)) == upper(acr.at(acr_idx)) {
+        // A boundary is index 0, or preceded by a space or a hyphen
+        if i == 0 or def.at(i - 1) == " " or def.at(i - 1) == "-" {
+          matches.push(i)
+          acr_idx += 1
+        }
+      }
+    }
+  }
 
-      // Case sensitive match
-      if acr_idx < acr.len() and upper(letter) == upper(acr.at(acr_idx)) {
+  // Pass 3: Pure case-insensitive fallback (if word boundaries didn't match perfectly)
+  if acr_idx < acr.len() {
+    matches = ()
+    acr_idx = 0
+    for i in range(def.len()) {
+      if acr_idx < acr.len() and upper(def.at(i)) == upper(acr.at(acr_idx)) {
         matches.push(i)
         acr_idx += 1
       }
@@ -91,17 +101,31 @@
   }
 
   let content = []
-  let i = 0
 
+  // Safe exit if definition doesn't contain the acronym letters
+  if matches.len() == 0 {
+    return [#def]
+  }
+
+  let i = 0
   while i < matches.len() {
-    if i > 0 {
+    if i == 0 {
+      // Safely grab any prefix characters before the first match
+      if matches.at(0) > 0 {
+        content += [#def.slice(0, matches.at(0))]
+      }
+    } else {
       content += [#def.slice(matches.at(i - 1) + 1, matches.at(i))]
     }
+    
     content += [#text(weight: "bold", def.at(matches.at(i)))]
     i += 1
   }
 
-  content += [#def.slice(matches.at(i - 1) + 1)]
+  // Append any trailing characters
+  if matches.last() + 1 < def.len() {
+    content += [#def.slice(matches.last() + 1)]
+  }
 
   content
 }


### PR DESCRIPTION
This PR resolves an issue in the custom `highlight-words` function in the acrostiche fork where acronyms with mixed-case definitions (like "Time-to-Interactive" for `TTI`) would evaluate incorrectly, resulting in scrambled formatting such as **TTi**me-To-Interactive.

**The Bugs:**

1. **State Leakage:** The original fallback case-insensitive loop did not reset the `matches` array or the `acr_idx` pointer when the first case-sensitive loop failed. This caused the loop to start searching for the second letter of the acronym at index 0, matching the first letter twice.
2. **Dropped Prefixes:** The `while` loop responsible for rendering the final content dropped any preceding characters if the first matched letter did not sit at index 0 of the definition.

**The Solution:**
The `highlight-words` function has been rewritten to use a more robust, three-pass matching system:

* **Pass 1:** Strict case-sensitive match (Preserves standard acronyms like `SPA` -> **S**ingle **P**age **A**pplication).
* **Pass 2:** Case-insensitive match prioritizing word boundaries (spaces and hyphens). This safely captures mixed-case phrases like `TTI` -> **T**ime-**t**o-**I**nteractive.
* **Pass 3:** A linear case-insensitive fallback just in case the word-boundary pass fails.

Variables are properly reset between passes, and the rendering loop now safely grabs prefix strings before the first highlighted letter.

**Testing:**

* Verified `acr("SPA")` correctly outputs **S**ingle **P**age **A**pplication.
* Verified `acr("TTI")` correctly outputs **T**ime-**t**o-**I**nteractive.

Please note that I implemented this change with the help of Gemini.