### PR TITLE
support custom heading numbering and supplements (e.g. Appendices)

### DIFF
--- a/src/typxidian.typ
+++ b/src/typxidian.typ
@@ -260,9 +260,9 @@
           ]))]
       } else {
         content = align(chapter-alignment, [
-          #text(size: font-sizes.subsection, fill: chapter-color)[#upper(chapter-supplement) #(
-              counter(heading).get().first()
-            )]
+          #text(size: font-sizes.subsection, fill: chapter-color)[
+            #upper(it.supplement) #numbering(it.numbering, counter(heading).get().first())
+          ]
           #linebreak()
           #v(0.35em)
           #text(size: font-sizes.chapter)[#it.body]
@@ -305,7 +305,12 @@
       font-sizes.subsubsection
     }
 
-    text(size: text-size)[#block([#context counter(heading).display() #h(0.35em)  #it.body])]
+    text(size: text-size)[#block([
+      #if it.numbering != none [
+        #context counter(heading).display(it.numbering) #h(0.35em)
+      ]
+      #it.body
+    ])]
     v(0.75em)
   }
 
@@ -353,9 +358,21 @@
         body = [#curr-page #h(1fr) #header-title]
       } else {
         alignment = left
-        let header-title = query(selector(heading.where(level: 1)).before(here())).last().body
-        body = [#chapter-supplement #counter(heading.where(level: 1)).display(): #header-title
-          #h(1fr) #curr-page]
+        let last-heading = query(selector(heading.where(level: 1)).before(here())).last()
+        
+        // Format the number using the heading's own numbering style
+        let formatted-num = if last-heading.numbering != none {
+          numbering(last-heading.numbering, counter(heading).at(last-heading.location()).first())
+        }
+        
+        body = [
+          // Only display the supplement and number if the heading actually has numbering
+          #if formatted-num != none [
+            #last-heading.supplement #formatted-num: 
+          ]
+          #last-heading.body
+          #h(1fr) #curr-page
+        ]
       }
 
       align(alignment, [
@@ -385,7 +402,7 @@
 
   if after-content != none {
     context {
-      show heading: set heading(supplement: "extra-content")
+      show heading.where(numbering: none): set heading(supplement: "extra-content")
       after-content
     }
   }


### PR DESCRIPTION
Hey there! I finished my thesis using the template and wanted to contribute the last few changes I made. Feel free to close / accept them as you see fit.

This PR updates the template to respect custom heading `numbering` and `supplement` overrides. Previously, the template hardcoded the global chapter-supplement and default numbering schemes into the chapter headings, subheadings, and page headers. This prevented users from easily creating appendices with custom lettering (e.g., Appendix A, Appendix B).

I noticed that there already exists an appendix utility in the source code, but I think this solution is more elegant as it doesn't lead to code duplication and manual header re-drawing.

**Key Changes**
* **Dynamic Headings (Level 1):** Updated the `show heading.where(level: 1)` rule to use `it.supplement` and `numbering(it.numbering, ...)` instead of hardcoding the chapter supplement and raw counter value.
* **Dynamic Subheadings (Levels 2-4):** Updated subheading rules to display using `it.numbering` so they correctly inherit parent numbering formats.
* **Smart Page Headers:** Modified the header logic (for odd pages) to extract `last-heading.numbering` and `last-heading.supplement`. Headers will now accurately display "Appendix A: ..." instead of "Chapter [Raw Counter]: ...".
* **`after-content` Fix:** Constrained the `"extra-content"` supplement override to only apply to headings without numbering (`where(numbering: none)`), ensuring it doesn't accidentally overwrite custom numbered appendices.

**Usage Example**
Users can now append an appendix by overriding the numbering format and supplement:
```typst
#{
  show: appendix
  include "appendix/a-data.typ"
  include "appendix/b-implementation-details.typ"
}
```

Where `appendix` is defined as
```
#let appendix(body) = {
  show heading: set heading(numbering: "A", supplement: [Appendix])
  counter(heading).update(0)
  body
}
```

This is how it looks in practice (appendix follows same header style):
<img width="868" height="483" alt="image" src="https://github.com/user-attachments/assets/2d50c406-0251-41a9-9738-9de5852fdee0" />


Compared to the older helper (appendix does not follow document header style):
<img width="912" height="465" alt="image" src="https://github.com/user-attachments/assets/f435484b-3e47-4d29-b90e-36ae7617bea3" />
